### PR TITLE
Add support for custom aws-auth configmap name and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The `aws-auth-manager` provides the ability to define multiple `AWSAuthItem` obj
 
 ## Features
 
+- Allow to specify name and namespace for the auth configmap to test the controller in an existing installation.
 - Create the `aws-auth` configmap if it's missing.
 - Prevent manual changes to `aws-auth` by triggering a reconciliation loop and rebuilding it.
 - Deploy a validation webhook to validate `userArn` and `roleArn` fields.

--- a/controllers/awsauthitem_controller_test.go
+++ b/controllers/awsauthitem_controller_test.go
@@ -18,19 +18,20 @@ import (
 var _ = Describe("AWSAuth controller", func() {
 
 	SetDefaultEventuallyTimeout(time.Second * 10)
-	authCm := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      AWSAuthMapName,
-			Namespace: AWSAuthMapNamespace,
-		},
-	}
 
 	It("Should manage the aws-auth ConfigMap", func() {
+		authCm := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      reconciler.AWSAuthConfigMapName,
+				Namespace: reconciler.AWSAuthConfigMapNamespace,
+			},
+		}
+
 		By("Creating three AWSAuthItem objects")
 		userItem := awsauthv1alpha1.AWSAuthItem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "user-item",
-				Namespace: AWSAuthMapNamespace,
+				Namespace: reconciler.AWSAuthConfigMapNamespace,
 			},
 			Spec: awsauthv1alpha1.AWSAuthItemSpec{
 				MapUsers: []awsauthv1alpha1.MapUserItem{
@@ -52,7 +53,7 @@ var _ = Describe("AWSAuth controller", func() {
 		roleItem := awsauthv1alpha1.AWSAuthItem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "role-item",
-				Namespace: AWSAuthMapNamespace,
+				Namespace: reconciler.AWSAuthConfigMapNamespace,
 			},
 			Spec: awsauthv1alpha1.AWSAuthItemSpec{
 				MapRoles: []awsauthv1alpha1.MapRoleItem{
@@ -69,7 +70,7 @@ var _ = Describe("AWSAuth controller", func() {
 		mixedItem := awsauthv1alpha1.AWSAuthItem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mixed-item",
-				Namespace: AWSAuthMapNamespace,
+				Namespace: reconciler.AWSAuthConfigMapNamespace,
 			},
 			Spec: awsauthv1alpha1.AWSAuthItemSpec{
 				MapRoles: []awsauthv1alpha1.MapRoleItem{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -39,10 +39,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	ctx        context.Context
+	cancel     context.CancelFunc
+	reconciler *AWSAuthItemReconciler
 )
 
 func TestAPIs(t *testing.T) {
@@ -82,10 +83,13 @@ var _ = BeforeSuite(func() {
 	Expect(k8sManager).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&AWSAuthItemReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	reconciler = &AWSAuthItemReconciler{
+		Client:                    k8sManager.GetClient(),
+		Scheme:                    k8sManager.GetScheme(),
+		AWSAuthConfigMapName:      "aws-auth-dryrun",
+		AWSAuthConfigMapNamespace: "kube-system",
+	}
+	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -49,14 +49,15 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
+	var metricsAddr, probeAddr, AWSAuthConfigMapName, AWSAuthConfigMapNamespace string
 	var enableLeaderElection bool
-	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&AWSAuthConfigMapName, "aws-auth-configmap-name", "aws-auth", "The name of the aws-auth configmap.")
+	flag.StringVar(&AWSAuthConfigMapNamespace, "aws-auth-configmap-namespace", "kube-system", "The namespace of the aws-auth configmap.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -79,8 +80,10 @@ func main() {
 	}
 
 	if err = (&controllers.AWSAuthItemReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                    mgr.GetClient(),
+		Scheme:                    mgr.GetScheme(),
+		AWSAuthConfigMapName:      AWSAuthConfigMapName,
+		AWSAuthConfigMapNamespace: AWSAuthConfigMapNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AWSAuthItem")
 		os.Exit(1)


### PR DESCRIPTION
Fix https://github.com/maruina/aws-auth-manager/issues/19

Add flags to pass a custom configmap name and namespace. This allow to run the controller alongside an existing `aws-auth` configmap, create a new one and diff them before putting it into production.