### PR TITLE
Reduce complexity to fix linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,9 +28,6 @@ linters:
     - cyclop
     # See https://github.com/golangci/golangci-lint/issues/3906
     - depguard
-    # Temporary disable
-    - gocognit
-    - nestif
     # deprecated linters
     - deadcode
     - golint

--- a/api/v1alpha1/awsauthitem_types.go
+++ b/api/v1alpha1/awsauthitem_types.go
@@ -21,7 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const AWSAuthFinalizer = "finalizer.aws.maruina.k8s"
+const (
+	AWSAuthFinalizer       = "finalizer.aws-auth-manager.maruina.k8s"
+	AWSAuthAnnotationKey   = "aws-auth-manager.maruina.k8s/managed"
+	AWSAuthAnnotationValue = "true"
+)
 
 const (
 	// ReadyCondition is the name of the Ready condition implemented by all toolkit

--- a/controllers/awsauthitem_controller.go
+++ b/controllers/awsauthitem_controller.go
@@ -153,9 +153,11 @@ func (r *AWSAuthItemReconciler) reconcile(ctx context.Context, item awsauthv1alp
 	if errors.IsNotFound(err) {
 		authCm = corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        r.AWSAuthConfigMapName,
-				Namespace:   r.AWSAuthConfigMapNamespace,
-				Annotations: make(map[string]string),
+				Name:      r.AWSAuthConfigMapName,
+				Namespace: r.AWSAuthConfigMapNamespace,
+				Annotations: map[string]string{
+					awsauthv1alpha1.AWSAuthAnnotationKey: awsauthv1alpha1.AWSAuthAnnotationValue,
+				},
 			},
 			Data: map[string]string{
 				"MapUsers": "",


### PR DESCRIPTION
- Enable `gocognit` and `nestif` which I disabled in https://github.com/maruina/aws-auth-manager/pull/174
- Add annotation that we are managing the AWS Auth configmap
- Since we can't guarantee the order of `r.List()`, we remove the hashing section as items in different order will give a different hash